### PR TITLE
"Feature gate" crates, un-default non-Rust crates.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,22 +5,43 @@ authors = ["Brian Anderson <banderson@mozilla.com>"]
 description = "The missing batteries of Rust"
 license = "MIT/Apache-2.0"
 
+[features]
+default = [
+    "bitflags",
+    "docopt",
+    "env_logger",
+    "itertools",
+    "lazy_static",
+    "libc",
+    "log",
+    "num",
+    "rand",
+    "regex",
+    "rustc-serialize",
+    "semver",
+    "tempdir",
+    "time",
+    "toml",
+    "url",
+]
+all = ["default", "flate2", "hyper"]
+
 [dependencies]
-bitflags = "0.3.0"
-docopt = "0.6.67"
-env_logger = "0.3.1"
-flate2 = "0.2.7"
-hyper = "0.6.1"
-itertools = "0.3.21"
-lazy_static = "0.1.11"
-libc = "0.1.8"
-log = "0.3.1"
-num = "0.1.25"
-rand = "0.3.8"
-regex = "0.1.39"
-rustc-serialize = "0.3.15"
-semver = "0.1.19"
-tempdir = "0.3.4"
-time = "0.1.3"
-toml = "0.1.21"
-url = "0.2.35"
+bitflags = { version = "0.3.0", optional = true }
+docopt = { version = "0.6.67", optional = true }
+env_logger = { version = "0.3.1", optional = true }
+flate2 = { version = "0.2.7", optional = true }
+hyper = { version = "0.6.1", optional = true }
+itertools = { version = "0.3.21", optional = true }
+lazy_static = { version = "0.1.11", optional = true }
+libc = { version = "0.1.8", optional = true }
+log = { version = "0.3.1", optional = true }
+num = { version = "0.1.25", optional = true }
+rand = { version = "0.3.8", optional = true }
+regex = { version = "0.1.39", optional = true }
+rustc-serialize = { version = "0.3.15", optional = true }
+semver = { version = "0.1.19", optional = true }
+tempdir = { version = "0.3.4", optional = true }
+time = { version = "0.1.30", optional = true }
+toml = { version = "0.1.21", optional = true }
+url = { version = "0.2.35", optional = true }

--- a/README.md
+++ b/README.md
@@ -102,15 +102,16 @@ the Rust stable 1.2 release.
   library, and is still the most popular way to log information about
   what your Rust program is. Official [rust-lang] crate.
 
-* [`flate2-0.2.7`](https://crates.io/crates/flate2/0.2.7). Basic
-  [deflate](https://en.wikipedia.org/wiki/DEFLATE) compression and
-  decompression, via bindings to the [miniz
+* [`flate2-0.2.7`](https://crates.io/crates/flate2/0.2.7)
+  *(Optional)*. Basic [deflate](https://en.wikipedia.org/wiki/DEFLATE) compression and decompression, via bindings to the [miniz
   library](https://code.google.com/p/miniz/).
+  **To enable**: use the **flate2** feature.
 
-* [`hyper-0.6.1`](https://crates.io/crates/hyper/0.6.1). The most
-  full-featured pure-Rust implementation of HTTP. Trusted by
+* [`hyper-0.6.1`](https://crates.io/crates/hyper/0.6.1) *(Optional)*.
+  The most full-featured pure-Rust implementation of HTTP. Trusted by
   [Servo](https://github.com/servo/servo) and maintained by Mozilla's
   [seanmonstar](https://github.com/seanmonstar) so it's pretty solid.
+  **To enable**: use the **hyper** feature.
 
 * [`itertools-0.3.21`](https://crates.io/crates/itertools/0.3.21).
   When it comes to iterators, this crate has everything *including*
@@ -136,7 +137,7 @@ the Rust stable 1.2 release.
 
 * [`tempdir-0.3.4`](https://crates.io/crates/tempdir/0.3.4)
 
-* [`time-0.1.3`](https://crates.io/crates/time/0.1.3)
+* [`time-0.1.30`](https://crates.io/crates/time/0.1.30)
 
 * [`toml-0.1.21`](https://crates.io/crates/toml/0.1.21)
 
@@ -146,7 +147,35 @@ the Rust stable 1.2 release.
 
 # Advanced details for the crate connoisseur
 
-TODO: using crate features to enable crates selectively.
+Some of the crates in **stdx** are optional, and must be enabled
+explicitly in your manifest.  They might be disabled because they
+do not work well on all platforms, because they are very large, or
+because they require special environment configuration to build.
+
+You can enable these crates by listing the ones you want like so:
+
+```toml
+[dependencies.stdx]
+version = "0.102"
+features = ["flate2", "hyper"]
+```
+
+**Note**: Having a `[dependencies.stdx]` section *replaces* the short
+`stdx = "..."` line.
+
+You can also use `"all"` to just enable everything.
+
+If you want to go the other way, you can also select *just* the set of crates you want.  For example, if you only want the `env_logger`, `log`, and `num` crates, you could use the following:
+
+```toml
+[dependencies.stdx]
+version = "0.102"
+default-features = false
+features = ["env_logger", "log", "num"]
+```
+
+There are more details about how features work in the
+[Cargo documentation](http://doc.crates.io/manifest.html#the-[features]-section).
 
 # Past batteries
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,53 +1,53 @@
-extern crate bitflags as bitflags_;
-pub use bitflags_ as bitflags;
+#[cfg(feature = "bitflags")] extern crate bitflags as bitflags_;
+#[cfg(feature = "bitflags")] pub use bitflags_ as bitflags;
 
-extern crate docopt as docopt_;
-pub use docopt_ as docopt;
+#[cfg(feature = "docopt")] extern crate docopt as docopt_;
+#[cfg(feature = "docopt")] pub use docopt_ as docopt;
 
-extern crate env_logger as env_logger_;
-pub use env_logger_ as env_logger;
+#[cfg(feature = "env_logger")] extern crate env_logger as env_logger_;
+#[cfg(feature = "env_logger")] pub use env_logger_ as env_logger;
 
-extern crate flate2 as flate2_;
-pub use flate2_ as flate2;
+#[cfg(feature = "flate2")] extern crate flate2 as flate2_;
+#[cfg(feature = "flate2")] pub use flate2_ as flate2;
 
-extern crate hyper as hyper_;
-pub use hyper_ as hyper;
+#[cfg(feature = "hyper")] extern crate hyper as hyper_;
+#[cfg(feature = "hyper")] pub use hyper_ as hyper;
 
-extern crate itertools as itertools_;
-pub use itertools_ as itertools;
+#[cfg(feature = "itertools")] extern crate itertools as itertools_;
+#[cfg(feature = "itertools")] pub use itertools_ as itertools;
 
-extern crate lazy_static as lazy_static_;
-pub use lazy_static_ as lazy_static;
+#[cfg(feature = "lazy_static")] extern crate lazy_static as lazy_static_;
+#[cfg(feature = "lazy_static")] pub use lazy_static_ as lazy_static;
 
-extern crate libc as libc_;
-pub use libc_ as libc;
+#[cfg(feature = "libc")] extern crate libc as libc_;
+#[cfg(feature = "libc")] pub use libc_ as libc;
 
-extern crate log as log_;
-pub use log_ as log;
+#[cfg(feature = "log")] extern crate log as log_;
+#[cfg(feature = "log")] pub use log_ as log;
 
-extern crate num as num_;
-pub use num_ as num;
+#[cfg(feature = "num")] extern crate num as num_;
+#[cfg(feature = "num")] pub use num_ as num;
 
-extern crate rand as rand_;
-pub use rand_ as rand;
+#[cfg(feature = "rand")] extern crate rand as rand_;
+#[cfg(feature = "rand")] pub use rand_ as rand;
 
-extern crate regex as regex_;
-pub use regex_ as regex;
+#[cfg(feature = "regex")] extern crate regex as regex_;
+#[cfg(feature = "regex")] pub use regex_ as regex;
 
-extern crate rustc_serialize as rustc_serialize_;
-pub use rustc_serialize_ as rustc_serialize;
+#[cfg(feature = "rustc_serialize")] extern crate rustc_serialize as rustc_serialize_;
+#[cfg(feature = "rustc_serialize")] pub use rustc_serialize_ as rustc_serialize;
 
-extern crate semver as semver_;
-pub use semver_ as semver;
+#[cfg(feature = "semver")] extern crate semver as semver_;
+#[cfg(feature = "semver")] pub use semver_ as semver;
 
-extern crate tempdir as tempdir_;
-pub use tempdir_ as tempdir;
+#[cfg(feature = "tempdir")] extern crate tempdir as tempdir_;
+#[cfg(feature = "tempdir")] pub use tempdir_ as tempdir;
 
-extern crate time as time_;
-pub use time_ as time;
+#[cfg(feature = "time")] extern crate time as time_;
+#[cfg(feature = "time")] pub use time_ as time;
 
-extern crate toml as toml_;
-pub use toml_ as toml;
+#[cfg(feature = "toml")] extern crate toml as toml_;
+#[cfg(feature = "toml")] pub use toml_ as toml;
 
-extern crate url as url_;
-pub use url_ as url;
+#[cfg(feature = "url")] extern crate url as url_;
+#[cfg(feature = "url")] pub use url_ as url;


### PR DESCRIPTION
This makes every crate optional, with a nearly full set enabled by default.  The crates that are *not* enabled by default are those that do not build cleanly on Windows without additional configuration.  There is also an "all" feature that pulls in everything.

The README now contains the following:

> They might be disabled because they do not work well on all platforms, because they are very large, or because they require special environment configuration to build.

I propose that this be the general position taken with stdx: if a crate does not build on all platforms, is very large (which would disincentivise people from using stdx on smaller projects), or requires additional external configuration (downloading compilers, headers, libraries, changing environment variables, etc.), then it should *not* be in the default set.  This would include all crates that depend on non-Rust, non-ubiquitous libraries (*i.e.* things like POSIX on *nix systems, or Win32 on Windows, are OK.)

In other words: if it won't build on a fresh OS install that has *just* had Rust installed, it probably shouldn't be default.

I've gated hyper on the basis that it depends on openssl.  I have already gone through the pain of working out how to set up my machine to build this... except now I find it doesn't work any more and I have no idea *why*.  I *have* MinGW and the OpenSSL headers installed, they just... stopped working for some reason.

I've gated flate2 on the basis of Tomaka's complaints in the Discourse thread discussion of stdx.  It builds for me, but then, I have a non-default configuration.

I have *not* gated time, as the problem there appears to be depending on a very old version of the crate; I've just changed the version number from 0.1.3 to 0.1.30.