### PR TITLE
Check for duplicated dependencies in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+sudo: false
+language: rust
+
+rust: stable
+
+before_install:
+  - cargo install cargo-tree --debug
+  - export PATH=$HOME/.cargo/bin:$PATH
+
+script:
+  # Fail if there are any duplicate dependencies
+  - "[[ ! $(cargo tree -d | tee /dev/fd/2 ) ]]"
+
+# Copied from cargo-tree's .travis.yml
+addons:
+  apt:
+    sources:
+      - kalakris-cmake
+    packages:
+      - cmake

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,14 @@
 sudo: false
 language: rust
+cache: cargo
 
 rust: stable
 
 before_install:
-  - cargo install cargo-tree --debug
+  - |
+      if ! hash cargo-tree 2>/dev/null; then
+          cargo install cargo-tree --debug
+      fi
   - export PATH=$HOME/.cargo/bin:$PATH
 
 script:


### PR DESCRIPTION
This currently fails though. :crying_cat_face: 

```
bitflags v0.8.2
├── clap v2.24.2
│   └── stdx v0.117.0-rc (file:///home/travis/build/brson/stdx)
└── openssl v0.9.12
    └── native-tls v0.1.2
        └── hyper-native-tls v0.2.2
            └── reqwest v0.6.2
                └── stdx v0.117.0-rc (file:///home/travis/build/brson/stdx) (*)

bitflags v0.9.0
└── stdx v0.117.0-rc (file:///home/travis/build/brson/stdx)

serde v0.9.15
└── ndarray v0.9.1
    └── stdx v0.117.0-rc (file:///home/travis/build/brson/stdx)

serde v1.0.7
├── chrono v0.3.1
│   └── stdx v0.117.0-rc (file:///home/travis/build/brson/stdx)
├── reqwest v0.6.2
│   └── stdx v0.117.0-rc (file:///home/travis/build/brson/stdx) (*)
├── serde_json v1.0.2
│   ├── reqwest v0.6.2 (*)
│   └── stdx v0.117.0-rc (file:///home/travis/build/brson/stdx) (*)
├── serde_urlencoded v0.5.1
│   └── reqwest v0.6.2 (*)
├── stdx v0.117.0-rc (file:///home/travis/build/brson/stdx) (*)
└── toml v0.4.1
    └── stdx v0.117.0-rc (file:///home/travis/build/brson/stdx) (*)
```