### PR TITLE
added semver example

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,1 @@
+language: rust

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ rand = "0.3.15"
 rayon = "0.7.1"
 regex = "0.2.2"
 reqwest = { version = "0.6.2", features = ["serde"] }
+semver = "0.7.0"
 serde = "1.0.8"
 serde_json = "1.0.2"
 tar = "0.4.13"

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Current revision: `stdx` 0.118.0-rc, for Rust 1.18, June 8, 2017.
 | Parallel iteration             | [`rayon = "0.7.1"`]        | [📖][d-rayon]       |
 | Regular expressions            | [`regex = "0.2.2"`]        | [📖][d-regex]       |
 | HTTP client                    | [`reqwest = "0.6.2"`]      | [📖][d-reqwest]     |
+| Semantic versioning            | [`semver = "0.7.0"`]       | [📖][d-semver]      |
 | Serialization                  | [`serde = "1.0.8"`]        | [📖][d-serde]       |
 | JSON                           | [`serde_json = "1.0.2"`]   | [📖][d-serde_json]  |
 | Tar archives                   | [`tar = "0.4.13"`]         | [📖][d-tar]         |
@@ -827,6 +828,41 @@ fn main() {
     let res = client.post("http://httpbin.org/post")
         .json(&map)
         .send();
+}
+```
+
+&nbsp;&NewLine;&nbsp;&NewLine;&nbsp;&NewLine;
+
+
+<a id="semver"></a>
+### `semver = "0.7.0"` &emsp; [📖][d-semver]
+
+Parsing and comparison of semantic version numbers. [Cargo] uses SemVer to determine which versions of packages need to be installed.
+
+**Example**: [`examples/semver.rs`]
+
+```rust
+extern crate semver;
+
+fn main() {
+    // Construct Version objects
+    assert!(Version::parse("1.2.3") == Ok(Version {
+        major: 1,
+        minor: 2,
+        patch: 3,
+        pre: vec!(),
+        build: vec!(),
+    }));
+
+    // Compare Versions
+    assert!(Version::parse("1.2.3-alpha") != Version::parse("1.2.3-beta"));
+    assert!(Version::parse("1.2.3-alpha2") >  Version::parse("1.2.0"));
+
+    // Increment patch number of mutable Version
+    let mut bugfix_release = Version::parse("1.0.0").unwrap();
+    bugfix_release.increment_patch();
+
+    assert_eq!(Ok(bugfix_release), Version::parse("1.0.1"));
 }
 ```
 

--- a/examples/semver.rs
+++ b/examples/semver.rs
@@ -1,0 +1,24 @@
+extern crate semver;
+
+use semver::Version;
+
+fn main() {
+    // Construct Version objects
+    assert!(Version::parse("1.2.3") == Ok(Version {
+        major: 1,
+        minor: 2,
+        patch: 3,
+        pre: vec!(),
+        build: vec!(),
+    }));
+
+    // Compare Versions
+    assert!(Version::parse("1.2.3-alpha") != Version::parse("1.2.3-beta"));
+    assert!(Version::parse("1.2.3-alpha2") >  Version::parse("1.2.0"));
+
+    // Increment patch number of mutable Version
+    let mut bugfix_release = Version::parse("1.0.0").unwrap();
+    bugfix_release.increment_patch();
+
+    assert_eq!(Ok(bugfix_release), Version::parse("1.0.1"));
+}


### PR DESCRIPTION
I took a crack at this easy issue #50 to add semver.  I just used the examples from [Crate semver](http://www.steveklabnik.com/semver/semver/index.html) though that may not be sufficient.  I am using Rust 1.18 so I just checked that "cargo build" runs, and "cargo build --examples" does not seem to work for me.  I did also try "cargo build --example semver" which runs ok.  Also, I tried to copy the syntax of the other examples in the README, but it doesn't seem to render the same way.

I'm a Rust newbie just starting to read the Rust Lang book.  If I can continue to contribute to the stdx issues, please let me know.