### PR TITLE
bump toml version to 0.4.5 allow use of pretty strings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ serde_json = "1.0.2"
 tar = "0.4.13"
 tempdir = "0.3.5"
 threadpool = "1.4.0"
-toml = "0.4.2"
+toml = "0.4.5"
 url = "1.5.1"
 walkdir = "1.0.7"
 


### PR DESCRIPTION
toml 0.4.5 stabilized pretty strings which is a pretty useful feature.

vitiral/artifact#164 needs this to consume stdx